### PR TITLE
add support for the .yml extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,31 +1,58 @@
+
 var fs = require('fs');
 var extname = require('path').extname;
 var yaml = require('yaml-js');
 
-function parse(ext, data) {
-  if (ext === '.json') {
-    return JSON.parse(data);
-  }
-  if (ext === '.yaml') {
-    return yaml.load(data);
-  }
-  return new Error('Invalid metadata file type');
-}
+/**
+ * Expose `readMetadata`.
+ */
 
-module.exports = exports = function(path, done) {
-  var ext = extname(path);
+module.exports = exports = readMetadata;
+
+/**
+ * Read a metadata file by `path` and callback `done(err, obj)`.
+ *
+ * @param {String} path
+ * @param {Function} done
+ */
+
+function readMetadata(path, done) {
   fs.readFile(path, 'utf-8', function(err, data){
     if (err) return done(err);
-    var result = parse(ext, data);
-    if (result instanceof Error) {
-      return done(result);
-    }
+    var parse = parser(path);
+    if (!parse) return done(new Error('Invalid metadata file type.'));
+    var result = parse(data);
     done(null, result);
   });
 };
 
+/**
+ * Read a metadata file synchronously by `path`.
+ *
+ * @param {String} path
+ * @return {Object}
+ */
+
 exports.sync = function(path) {
-  var ext = extname(path);
+  var parse = parser(path);
+  if (!parse) throw new Error('Invalid metadata file type.');
   var data = fs.readFileSync(path, 'utf-8');
-  return parse(ext, data);
+  return parse(data);
 };
+
+/**
+ * Return a parser for a given `file`.
+ *
+ * @param {String} file
+ * @return {Function}
+ */
+
+function parser(file) {
+  switch (extname(file)) {
+    case '.json':
+      return JSON.parse;
+    case '.yaml':
+    case '.yml':
+      return yaml.load;
+  }
+}

--- a/test/fixtures/metadata.yml
+++ b/test/fixtures/metadata.yml
@@ -1,0 +1,1 @@
+name: Batman

--- a/test/index.js
+++ b/test/index.js
@@ -14,6 +14,11 @@ describe('read-metadata', function () {
       assert.equal(data.name, 'Batman');
       done();
     });
+    it('should load yml files', function (done) {
+      var data = load.sync('test/fixtures/metadata.yml');
+      assert.equal(data.name, 'Batman');
+      done();
+    });
   });
 
   describe('loading async', function () {
@@ -25,6 +30,12 @@ describe('read-metadata', function () {
     });
     it('should load yaml files', function (done) {
       load('test/fixtures/metadata.yaml', function(err, data){
+        assert.equal(data.name, 'Batman');
+        done();
+      });
+    });
+    it('should load yml files', function (done) {
+      load('test/fixtures/metadata.yml', function(err, data){
         assert.equal(data.name, 'Batman');
         done();
       });


### PR DESCRIPTION
Realized that both `.yaml` and `.yml` are used for YAML files. Refactored a bit to make the extensions really clear and added doc blocks for clarity.

cc @anthonyshort 
